### PR TITLE
fix#52 AuthCallback在spring中接收参数异常

### DIFF
--- a/src/main/java/me/zhyd/oauth/model/AuthCallback.java
+++ b/src/main/java/me/zhyd/oauth/model/AuthCallback.java
@@ -1,7 +1,9 @@
 package me.zhyd.oauth.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.io.Serializable;
@@ -15,6 +17,8 @@ import java.io.Serializable;
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class AuthCallback implements Serializable {
 
     /**


### PR DESCRIPTION
fix#52 AuthCallback在spring中接收参数异常，需要有默认的构造方法,增加注解@AllArgsConstructor和@NoArgsConstructor