### PR TITLE
支持阿里云授权登录

### DIFF
--- a/src/main/java/me/zhyd/oauth/config/AuthDefaultSource.java
+++ b/src/main/java/me/zhyd/oauth/config/AuthDefaultSource.java
@@ -765,7 +765,7 @@ public enum AuthDefaultSource implements AuthSource {
 
         @Override
         public String accessToken() {
-                return "https://open-oauth.jd.com/oauth2/access_token";
+            return "https://open-oauth.jd.com/oauth2/access_token";
         }
 
         @Override
@@ -777,5 +777,31 @@ public enum AuthDefaultSource implements AuthSource {
         public String refresh() {
             return "https://open-oauth.jd.com/oauth2/refresh_token";
         }
+    },
+
+    /**
+     * 阿里云
+     */
+    ALIYUN {
+        @Override
+        public String authorize() {
+            return "https://signin.aliyun.com/oauth2/v1/auth";
+        }
+
+        @Override
+        public String accessToken() {
+            return "https://oauth.aliyun.com/v1/token";
+        }
+
+        @Override
+        public String userInfo() {
+            return "https://oauth.aliyun.com/v1/userinfo";
+        }
+
+        @Override
+        public String refresh() {
+            return "https://oauth.aliyun.com/v1/token";
+        }
     }
+
 }

--- a/src/main/java/me/zhyd/oauth/model/AuthUser.java
+++ b/src/main/java/me/zhyd/oauth/model/AuthUser.java
@@ -1,5 +1,6 @@
 package me.zhyd.oauth.model;
 
+import com.alibaba.fastjson.JSONObject;
 import lombok.*;
 import me.zhyd.oauth.enums.AuthUserGender;
 import java.io.Serializable;
@@ -17,7 +18,7 @@ import java.io.Serializable;
 @AllArgsConstructor
 public class AuthUser implements Serializable {
     /**
-     * 用户第三方系统的唯一id。在调用方集成改组件时，可以用uuid + source唯一确定一个用户
+     * 用户第三方系统的唯一id。在调用方集成该组件时，可以用uuid + source唯一确定一个用户
      *
      * @since 1.3.3
      */
@@ -66,5 +67,9 @@ public class AuthUser implements Serializable {
      * 用户授权的token信息
      */
     private AuthToken token;
+    /**
+     * 第三方平台返回的原始用户信息
+     */
+    private JSONObject rawUserInfo;
 
 }

--- a/src/main/java/me/zhyd/oauth/request/AuthAliyunRequest.java
+++ b/src/main/java/me/zhyd/oauth/request/AuthAliyunRequest.java
@@ -1,0 +1,58 @@
+package me.zhyd.oauth.request;
+
+import com.alibaba.fastjson.JSONObject;
+import me.zhyd.oauth.cache.AuthStateCache;
+import me.zhyd.oauth.config.AuthConfig;
+import me.zhyd.oauth.config.AuthDefaultSource;
+import me.zhyd.oauth.model.AuthCallback;
+import me.zhyd.oauth.model.AuthToken;
+import me.zhyd.oauth.model.AuthUser;
+
+/**
+ * 阿里云登录
+ *
+ * @see <a href=https://help.aliyun.com/document_detail/93696.html?spm=a2c4g.11186623.6.656.146f53e8Tz7IGi>阿里云授权（OAuth）文档</a>
+ */
+public class AuthAliyunRequest extends AuthDefaultRequest {
+
+    public AuthAliyunRequest(AuthConfig config) {
+        super(config, AuthDefaultSource.ALIYUN);
+    }
+
+    public AuthAliyunRequest(AuthConfig config, AuthStateCache authStateCache) {
+        super(config, AuthDefaultSource.ALIYUN, authStateCache);
+    }
+
+    @Override
+    protected AuthToken getAccessToken(AuthCallback authCallback) {
+        String response = doPostAuthorizationCode(authCallback.getCode());
+        JSONObject accessTokenObject = JSONObject.parseObject(response);
+        return AuthToken.builder()
+                .accessToken(accessTokenObject.getString("access_token"))
+                .expireIn(accessTokenObject.getIntValue("expires_in"))
+                .tokenType(accessTokenObject.getString("token_type"))
+                .idToken(accessTokenObject.getString("id_token"))
+                .refreshToken(accessTokenObject.getString("refresh_token"))
+                .build();
+    }
+
+    /*
+     * 用户信息示例（主账号登录时）
+     * {
+     *      "sub":"PPPpppP+NRsXg/aaAaAAaA==",
+     *      "uid":"1222222222222222",
+     *      "login_name":"阿里云1234",
+     *      "requestid":"6f6af0f2-0f98-4410-a4b0-83bd5e1c1506",
+     *      "name":"root",
+     *      "bid":"22222",
+     *      "aid":"1222222222222222"
+     * }
+     */
+    @Override
+    protected AuthUser getUserInfo(AuthToken authToken) {
+        String userInfo = doGetUserInfo(authToken);
+        JSONObject jsonObject = JSONObject.parseObject(userInfo);
+        return AuthUser.builder().rawUserInfo(jsonObject).build();
+    }
+
+}


### PR DESCRIPTION
阿里云账号分为主账号和RAM用户，故阿里云登录获取到的用户信息和其它第三方登录获取到的用户信息差异略大，所以我在AuthUser.java新增了一个rawUserInfo(JSONObject类型)字段，存放原始的用户信息
（因为改动了AuthUser.java，可能不符合原作者预期，如果耽误了大佬不必要的审核时间，深感抱歉）
