### PR TITLE
[WIP] 添加发布快照的 workflow

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -1,0 +1,44 @@
+name: Deploy SNAPSHOT
+
+on: 
+  push:
+    branches: [ dev ]
+    paths:
+      - src/**
+      - pom.xml
+  pull_request:
+    branches: [ dev ]
+    paths:
+      - src/**
+      - pom.xml
+
+jobs:
+  get-latest-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.2.0
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Cache m2 package
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: get current project version to set env.VERSION
+        run: echo "VERSION=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`" >> $GITHUB_ENV
+      - name: set snapshot version
+        if: ${{ !endsWith( env.VERSION , '-SNAPSHOT') }} 
+        run: mvn versions:set -DnewVersion=${{ env.VERSION }}-SNAPSHOT
+      - name: deploy snapshot to ossrh repository
+        run: mvn -B deploy -P snapshot
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,15 @@
   </build>
   <profiles>
     <profile>
+      <id>snapshot</id>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
+    <profile>
       <id>release</id>
       <build>
         <plugins>
@@ -222,10 +231,6 @@
           </plugins>
       </build>
       <distributionManagement>
-        <snapshotRepository>
-          <id>sonatype-nexus-snapshots</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </snapshotRepository>
         <repository>
           <id>sonatype-nexus-staging</id>
           <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>

--- a/src/test/java/me/zhyd/oauth/utils/GlobalAuthUtilsTest.java
+++ b/src/test/java/me/zhyd/oauth/utils/GlobalAuthUtilsTest.java
@@ -145,7 +145,7 @@ public class GlobalAuthUtilsTest {
         oauthParams.forEach((k, v) -> oauthParams.put(k, "\"" + GlobalAuthUtils.urlEncode(v) + "\""));
 
         String actual = "OAuth " + GlobalAuthUtils.parseMapToString(oauthParams, false).replaceAll("&", ", ");
-        assertEquals("OAuth oauth_nonce=\"sTj7Ivg73u052eXstpoS1AWQCynuDEPN\", oauth_signature=\"yHHq2J1W5QLAO8gGipnY1V%2Bzxqk%3D\", oauth_token=\"1961977975-PcFQaCnpN9h9xqtqHwHlpGBXFrHJ9bOLy7OtGAL\", oauth_consumer_key=\"HD0XLqzi5Wz0G08rh45Cg8mgh\", oauth_signature_method=\"HMAC-SHA1\", oauth_timestamp=\"1569751082\", oauth_version=\"1.0\"", actual);
+        assertEquals("OAuth oauth_nonce=\"sTj7Ivg73u052eXstpoS1AWQCynuDEPN\", oauth_signature=\"OsqHjRmBf7syxlz8lB7MRdzqEjY%3D\", oauth_token=\"1961977975-PcFQaCnpN9h9xqtqHwHlpGBXFrHJ9bOLy7OtGAL\", oauth_consumer_key=\"HD0XLqzi5Wz0G08rh45Cg8mgh\", oauth_signature_method=\"HMAC-SHA1\", oauth_timestamp=\"1569751082\", oauth_version=\"1.0\"", actual);
     }
 
     @Test
@@ -200,7 +200,7 @@ public class GlobalAuthUtilsTest {
         queryParams.put("name", "你好");
         queryParams.put("gender", "male");
 
-        assertEquals("J6MAQH1kcgUdj2jmygN3rdfI4lo=", GlobalAuthUtils.generateTwitterSignature(queryParams, "GET", TWITTER.userInfo(), "xxxxx", "xxxxx"));
+        assertEquals("20FYnV2aZnxNQtp+I0tpMRTvcx0=", GlobalAuthUtils.generateTwitterSignature(queryParams, "GET", TWITTER.userInfo(), "xxxxx", "xxxxx"));
     }
 
     @Test


### PR DESCRIPTION
发布快照开发已在 fork 仓库中完成开发。目前提交 PR，配置环境变量，完成最后的工作。

关于整个 workflow 相关解释可以参考 https://github.com/kang8/JustAuth/issues/2#issuecomment-881993138 和 https://github.com/kang8/JustAuth/issues/2#issuecomment-894655607 。

## 需要做的事

提交到 `ossrh` 需要用户名和密码，所以需要将它们设置成环境变量中。具体如何设置环境变量可以参考官方文档中的 [为仓库创建加密密码
](https://docs.github.com/cn/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository)

具体要创建两个变量，并与 workflow 中一致：
* OSSRH_USERNAME：ossrh 用户名
* OSSRH_TOKEN：ossrh 密码

在原有的 release profile 中，由于添加了 gpg 相关依赖，所以要添加 gpg 密钥才行，快照版本并不是强制需要 gpg，为了不把问题搞复杂，就舍弃原有的 release，新创建一个 snapshot profile 用于发布快照：相关代码可以看 [这里](https://github.com/kang8/JustAuth/blob/9fc3131640f7442eef54efb69e3ee575c07f53fc/pom.xml#L160-L168)

---

另外，在发布的过程中，运行了测试，发现最新的代码对于 twitter 的修改导致测试代码失效，所以我也修复了这个问题。