### PR TITLE
refactor: 重构 workflow

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -1,4 +1,4 @@
-name: Deploy snapshot for dev branch
+name: Deploy
 
 on: 
   push:
@@ -47,11 +47,17 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: get current project version to set env.VERSION
-        run: echo "VERSION=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`" >> $GITHUB_ENV
-      - name: set snapshot version
-        if: ${{ !endsWith( env.VERSION , '-SNAPSHOT') }} 
-        run: mvn versions:set -DnewVersion=${{ env.VERSION }}-SNAPSHOT
+      - name: setting snapshot version
+        run: |
+          import xml.etree.ElementTree as ET
+          tree = ET.parse("pom.xml")
+          version = tree.find("{http://maven.apache.org/POM/4.0.0}version")
+          print(version.text + "-SNAPSHOT")
+          if version.text.endswith("-SNAPSHOT") == False:
+            tree.find("{http://maven.apache.org/POM/4.0.0}version").text = version.text + "-SNAPSHOT"
+            ET.register_namespace("", "http://maven.apache.org/POM/4.0.0")
+            tree.write("pom.xml", "utf-8", True)
+        shell: python
       - name: deploy snapshot to ossrh repository
         run: mvn -B deploy -P snapshot -DskipTests
         env:

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -1,4 +1,4 @@
-name: Deploy SNAPSHOT
+name: Deploy snapshot for dev branch
 
 on: 
   push:
@@ -6,14 +6,29 @@ on:
     paths:
       - src/**
       - pom.xml
-  pull_request:
-    branches: [ dev ]
-    paths:
-      - src/**
-      - pom.xml
 
 jobs:
-  get-latest-tag:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.2.0
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Cache m2 package
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - run: mvn test
+
+  deploy-snapshot:
+    needs: test
+    if: ${{ success() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.2.0
@@ -38,7 +53,7 @@ jobs:
         if: ${{ !endsWith( env.VERSION , '-SNAPSHOT') }} 
         run: mvn versions:set -DnewVersion=${{ env.VERSION }}-SNAPSHOT
       - name: deploy snapshot to ossrh repository
-        run: mvn -B deploy -P snapshot
+        run: mvn -B deploy -P snapshot -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -2,7 +2,6 @@ name: test pull_request
 
 on: 
   pull_request:
-    branches: [ dev ]
     paths:
       - src/**
       - pom.xml

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,27 @@
+name: test pull_request
+
+on: 
+  pull_request:
+    branches: [ dev ]
+    paths:
+      - src/**
+      - pom.xml
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.2.0
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Cache m2 package
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - run: mvn test


### PR DESCRIPTION
本次 PR 主要有三个改动：
1. 解决 BUG

之前的流程有个问题：会对 PR 提交进行快照发布，但 PR 是开发者对现有仓库的改进或功能增强，并不能确保 PR 的质量。所以 PR 只是运行测试，以对 PR 内容质量的保证。

2. 将 push 和 PR 分开

将 workflow 流程分为测试和发布快照，这样做的好处是**当测试不通过时不会进行快照发布**。并且在观感上来看，一眼就可以看出是测试出问题还是发布了问题。

![image](https://user-images.githubusercontent.com/36906329/131149957-bbab1ca0-52f7-4954-a2b1-276fc29e4688.png)

> 上图，一眼就可以看出是发布快照出了问题。

3. 更新版本快照名，从 maven 插件命令替换成了python 脚本

这是基于性能的考虑，在之前使用 maven 插件中，使用了两个 maven 插件：
https://github.com/justauth/JustAuth/blob/21e23aadb9f99a93c432167e40a4f7aee604a0cb/.github/workflows/deploy-snapshot.yml#L35-L39
这些 maven 插件可以很好的替换 pom.xml 中的 version 属性。但是只是替换 version 这个功能，需要从中央仓库拉取代码，并执行整个插件流程，整体下来未免有点重。
在我浏览文档的过程中，发现在 GitHub Actions 中可以[使用 python 脚本](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-running-a-python-script)，于是重写了改地方：
```yml
- name: setting snapshot version
run: |
  import xml.etree.ElementTree as ET
  tree = ET.parse("pom.xml")
  version = tree.find("{http://maven.apache.org/POM/4.0.0}version")
  print(version.text + "-SNAPSHOT")
  if version.text.endswith("-SNAPSHOT") == False:
    tree.find("{http://maven.apache.org/POM/4.0.0}version").text = version.text + "-SNAPSHOT"
    ET.register_namespace("", "http://maven.apache.org/POM/4.0.0")
    tree.write("pom.xml", "utf-8", True)
shell: python
```
显著的成效是：将运行时间从之前使用 mavan 插件的 4s~17s 降低到了使用 python 脚本 **0s**。

