### PR TITLE
把Alipay独有的配置从AuthConfig里提取出来

### DIFF
--- a/src/main/java/me/zhyd/oauth/config/AuthConfig.java
+++ b/src/main/java/me/zhyd/oauth/config/AuthConfig.java
@@ -38,7 +38,10 @@ public class AuthConfig {
     /**
      * 支付宝公钥：当选择支付宝登录时，该值可用
      * 对应“RSA2(SHA256)密钥”中的“支付宝公钥”
+     *
+     * @deprecated 请使用AuthAlipayRequest的构造方法设置"alipayPublicKey"
      */
+    @Deprecated
     private String alipayPublicKey;
 
     /**

--- a/src/main/java/me/zhyd/oauth/request/AuthDefaultRequest.java
+++ b/src/main/java/me/zhyd/oauth/request/AuthDefaultRequest.java
@@ -72,7 +72,7 @@ public abstract class AuthDefaultRequest implements AuthRequest {
     @Override
     public AuthResponse login(AuthCallback authCallback) {
         try {
-            AuthChecker.checkCode(source, authCallback);
+            checkCode(authCallback);
             if (!config.isIgnoreCheckState()) {
                 AuthChecker.checkState(authCallback.getState(), source, authStateCache);
             }
@@ -84,6 +84,10 @@ public abstract class AuthDefaultRequest implements AuthRequest {
             Log.error("Failed to login with oauth authorization.", e);
             return this.responseError(e);
         }
+    }
+
+    protected void checkCode(AuthCallback authCallback) {
+        AuthChecker.checkCode(source, authCallback);
     }
 
     /**

--- a/src/main/java/me/zhyd/oauth/utils/AuthChecker.java
+++ b/src/main/java/me/zhyd/oauth/utils/AuthChecker.java
@@ -27,9 +27,6 @@ public class AuthChecker {
     public static boolean isSupportedAuth(AuthConfig config, AuthSource source) {
         boolean isSupported = StringUtils.isNotEmpty(config.getClientId())
             && StringUtils.isNotEmpty(config.getClientSecret());
-        if (isSupported && AuthDefaultSource.ALIPAY == source) {
-            isSupported = StringUtils.isNotEmpty(config.getAlipayPublicKey());
-        }
         if (isSupported && AuthDefaultSource.STACK_OVERFLOW == source) {
             isSupported = StringUtils.isNotEmpty(config.getStackOverflowKey());
         }
@@ -71,18 +68,13 @@ public class AuthChecker {
             // Facebook's redirect uri must use the HTTPS protocol
             throw new AuthException(AuthResponseStatus.ILLEGAL_REDIRECT_URI, source);
         }
-        // 支付宝在创建回调地址时，不允许使用localhost或者127.0.0.1
-        if (AuthDefaultSource.ALIPAY == source && GlobalAuthUtils.isLocalHost(redirectUri)) {
-            // The redirect uri of alipay is forbidden to use localhost or 127.0.0.1
-            throw new AuthException(AuthResponseStatus.ILLEGAL_REDIRECT_URI, source);
-        }
         // 微软的回调地址必须为https的链接或者localhost,不允许使用http
-        if(AuthDefaultSource.MICROSOFT== source && !GlobalAuthUtils.isHttpsProtocolOrLocalHost(redirectUri) ){
+        if (AuthDefaultSource.MICROSOFT == source && !GlobalAuthUtils.isHttpsProtocolOrLocalHost(redirectUri)) {
             // Microsoft's redirect uri must use the HTTPS or localhost
             throw new AuthException(AuthResponseStatus.ILLEGAL_REDIRECT_URI, source);
         }
         // 微软中国的回调地址必须为https的链接或者localhost,不允许使用http
-        if(AuthDefaultSource.MICROSOFT_CN== source && !GlobalAuthUtils.isHttpsProtocolOrLocalHost(redirectUri) ){
+        if (AuthDefaultSource.MICROSOFT_CN == source && !GlobalAuthUtils.isHttpsProtocolOrLocalHost(redirectUri)) {
             // Microsoft's redirect uri must use the HTTPS or localhost
             throw new AuthException(AuthResponseStatus.ILLEGAL_REDIRECT_URI, source);
         }
@@ -103,9 +95,7 @@ public class AuthChecker {
             return;
         }
         String code = callback.getCode();
-        if (source == AuthDefaultSource.ALIPAY) {
-            code = callback.getAuth_code();
-        } else if (source == AuthDefaultSource.HUAWEI) {
+        if (source == AuthDefaultSource.HUAWEI) {
             code = callback.getAuthorization_code();
         }
         if (StringUtils.isEmpty(code)) {

--- a/src/test/java/me/zhyd/oauth/AuthRequestBuilderTest.java
+++ b/src/test/java/me/zhyd/oauth/AuthRequestBuilderTest.java
@@ -3,10 +3,7 @@ package me.zhyd.oauth;
 import me.zhyd.oauth.config.AuthConfig;
 import me.zhyd.oauth.config.AuthDefaultSource;
 import me.zhyd.oauth.config.AuthExtendSource;
-import me.zhyd.oauth.request.AuthExtendRequest;
-import me.zhyd.oauth.request.AuthGiteeRequest;
-import me.zhyd.oauth.request.AuthGithubRequest;
-import me.zhyd.oauth.request.AuthRequest;
+import me.zhyd.oauth.request.*;
 import me.zhyd.oauth.utils.AuthStateUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -75,31 +72,39 @@ public class AuthRequestBuilderTest {
      */
     @Test
     public void build4() {
+        AuthConfig config = AuthConfig.builder()
+            .clientId("a")
+            .clientSecret("a")
+            .redirectUri("https://www.justauth.cn")
+            .authServerId("asd")
+            .agentId("asd")
+            .domainPrefix("asd")
+            .stackOverflowKey("asd")
+            .deviceId("asd")
+            .clientOsType(3)
+            .build();
+
         for (AuthDefaultSource value : AuthDefaultSource.values()) {
-            if (value == AuthDefaultSource.TWITTER) {
-                System.out.println(value.getTargetClass());
-                System.out.println("忽略 twitter");
-                continue;
+            switch (value) {
+                case TWITTER:
+                    System.out.println(value.getTargetClass());
+                    System.out.println("忽略 twitter");
+                    continue;
+                case ALIPAY: {
+                    // 单独给Alipay执行测试
+                    AuthRequest authRequest = new AuthAlipayRequest(config, "asd");
+                    System.out.println(value.getTargetClass());
+                    System.out.println(authRequest.authorize(AuthStateUtils.createState()));
+                    continue;
+                }
+                default:
+                    AuthRequest authRequest = AuthRequestBuilder.builder()
+                        .source(value.getName())
+                        .authConfig(config)
+                        .build();
+                    System.out.println(value.getTargetClass());
+                    System.out.println(authRequest.authorize(AuthStateUtils.createState()));
             }
-            AuthRequest authRequest = AuthRequestBuilder.builder()
-                .source(value.getName())
-                .authConfig(AuthConfig.builder()
-                    .clientId("a")
-                    .clientSecret("a")
-                    .redirectUri("https://www.justauth.cn")
-                    .alipayPublicKey("asd")
-                    .authServerId("asd")
-                    .agentId("asd")
-                    .domainPrefix("asd")
-                    .stackOverflowKey("asd")
-
-                    .deviceId("asd")
-                    .clientOsType(3)
-                    .build())
-                .build();
-            System.out.println(value.getTargetClass());
-            System.out.println(authRequest.authorize(AuthStateUtils.createState()));
         }
-
     }
 }


### PR DESCRIPTION
AuthConfig从设计上看本应是公共的参数，但是实际上里面揉杂了各种第三方服务独有的配置。虽然文档已经解释得很清楚了，但是我觉得设计良好的代码应该具备更强的约束，所以对AuthConfig做了一些小修改。考虑到对旧版本的兼容性，我对不合理的属性和方法标记了@Deprecated，并给出了注释说明

AuthChecker也存在相同的问题，作为一个工具类，它不应该了解任何AuthRequest的具体实现，否则check的逻辑在将来可能会无限膨胀

由于精力的关系，我暂时只处理了Alipay的第三方集成
