### PR TITLE
Switching GitHub Action to use Zulu Builds.

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Cache m2 package
         uses: actions/cache@v2
         with:
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'zulu'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Cache m2 package
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## What this PR does / why we need it:
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK including archived builds (major fixed versions). Replacing the build distro to Zulu is nice because some environments use a major fixed version such as Java 8.0.192, that many vendor builds don't support.
This PR is backwards compatible since GitHub Actions setup-java@v1 originally used Azul Zulu. 




