### PR TITLE
chore: 补全抖音平台缺失字段

### DIFF
--- a/src/main/java/me/zhyd/oauth/request/AuthDouyinRequest.java
+++ b/src/main/java/me/zhyd/oauth/request/AuthDouyinRequest.java
@@ -44,6 +44,7 @@ public class AuthDouyinRequest extends AuthDefaultRequest {
         JSONObject userInfoObject = JSONObject.parseObject(response);
         this.checkResponse(userInfoObject);
         JSONObject object = userInfoObject.getJSONObject("data");
+        authToken.setUnionId(object.getString("union_id"));
         return AuthUser.builder()
             .rawUserInfo(object)
             .uuid(object.getString("union_id"))
@@ -96,6 +97,7 @@ public class AuthDouyinRequest extends AuthDefaultRequest {
             .openId(dataObj.getString("open_id"))
             .expireIn(dataObj.getIntValue("expires_in"))
             .refreshToken(dataObj.getString("refresh_token"))
+            .refreshTokenExpireIn(dataObj.getIntValue("refresh_expires_in"))
             .scope(dataObj.getString("scope"))
             .build();
     }


### PR DESCRIPTION
## 补全抖音平台缺失字段

抖音平台的 `union_id` 字段和 `refresh_expires_in` 字段丢失，建议补齐到 `AuthUser` 对象
