### PR TITLE
补全抖音平台缺失字段传递

### DIFF
--- a/src/main/java/me/zhyd/oauth/request/AuthDouyinRequest.java
+++ b/src/main/java/me/zhyd/oauth/request/AuthDouyinRequest.java
@@ -44,6 +44,7 @@ public class AuthDouyinRequest extends AuthDefaultRequest {
         JSONObject userInfoObject = JSONObject.parseObject(response);
         this.checkResponse(userInfoObject);
         JSONObject object = userInfoObject.getJSONObject("data");
+        authToken.setUnionId(object.getString("union_id"));
         return AuthUser.builder()
             .rawUserInfo(object)
             .uuid(object.getString("union_id"))
@@ -96,6 +97,7 @@ public class AuthDouyinRequest extends AuthDefaultRequest {
             .openId(dataObj.getString("open_id"))
             .expireIn(dataObj.getIntValue("expires_in"))
             .refreshToken(dataObj.getString("refresh_token"))
+            .refreshTokenExpireIn(dataObj.getIntValue("refresh_expires_in"))
             .scope(dataObj.getString("scope"))
             .build();
     }

--- a/src/main/java/me/zhyd/oauth/request/AuthMicrosoftRequest.java
+++ b/src/main/java/me/zhyd/oauth/request/AuthMicrosoftRequest.java
@@ -6,9 +6,9 @@ import me.zhyd.oauth.config.AuthDefaultSource;
 
 /**
  * 微软登录
+ * update 2021-08-24  mroldx (xzfqq5201314@gmail.com)
  *
  * @author yangkai.shen (https://xkcoding.com)
- * @update:2021-08-24  mroldx (xzfqq5201314@gmail.com)
  * @since 1.5.0
  */
 public class AuthMicrosoftRequest extends AbstractAuthMicrosoftRequest {

--- a/src/main/java/me/zhyd/oauth/request/AuthWeChatEnterpriseThirdQrcodeRequest.java
+++ b/src/main/java/me/zhyd/oauth/request/AuthWeChatEnterpriseThirdQrcodeRequest.java
@@ -81,7 +81,7 @@ public class AuthWeChatEnterpriseThirdQrcodeRequest extends AbstractAuthWeChatEn
     /**
      * 获取token的URL
      *
-     * @return
+     * @return accessTokenUrl
      */
     protected String accessTokenUrl() {
         return UrlBuilder.fromBaseUrl(source.accessToken())


### PR DESCRIPTION
`union_id`,`refresh_expires_in`字段在传递过程中没有最后传递到 `AuthUser` 不利于持久化数据做Token管理，故补齐。

